### PR TITLE
add shebang to script

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,4 +1,4 @@
-
+#!/usr/bin/env bash
 VERSION=13.2.1
 
 module purge


### PR DESCRIPTION
without the top level shebang the rpm will write the `scritpt.sh` with `644` and not `755`. This should fix the issue.